### PR TITLE
SPIK-352 Can specify subprojects for builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,7 +102,12 @@ $ heroku config:set KEEP_PLAY_FORK_RUN=true"
 fi
 
 SBT_VERSION="$(get_supported_sbt_version ${BUILD_DIR})"
-SBT_TASKS="compile stage"
+
+if [ "$SBT_PROJECT" ]; then
+    SBT_TASKS="$SBT_PROJECT/compile $SBT_PROJECT/stage"
+else
+    SBT_TASKS="compile stage"
+fi
 
 # To run any tasks before the actual build, configure the environment
 # $ heroku config:set SBT_PRE_TASKS=flyway:info


### PR DESCRIPTION
When your `build.sbt` has multiple projects, set the environment variable SBT_PROJECT to indicate which to use. This cuts down on compilation time & slug size for the deployed system.
